### PR TITLE
Corrected Division examples

### DIFF
--- a/manuscript/03-02-operators.md
+++ b/manuscript/03-02-operators.md
@@ -75,7 +75,7 @@ True
 
 ## Division
 
-`27//7` divides 27 by 7 and returns a floating point result
+`27/7` divides 27 by 7 and returns a floating point result
 
 `27//7` divides 27 by 7 and returns an integer result.
 


### PR DESCRIPTION
Both division examples used "27//7". I changed the floating point example to "27/7".